### PR TITLE
rockchipmpp: Add mppvpxalphadecodebin element

### DIFF
--- a/gst/rockchipmpp/gstmpp.c
+++ b/gst/rockchipmpp/gstmpp.c
@@ -36,6 +36,7 @@
 #include "gstmppjpegenc.h"
 #include "gstmppjpegdec.h"
 #include "gstmppvideodec.h"
+#include "gstmppvpxalphadecodebin.h"
 
 GST_DEBUG_CATEGORY_STATIC (mpp_debug);
 #define GST_CAT_DEFAULT mpp_debug
@@ -381,6 +382,14 @@ plugin_init (GstPlugin * plugin)
   if (!gst_element_register (plugin, "mppjpegdec", GST_RANK_PRIMARY + 1,
           gst_mpp_jpeg_dec_get_type ()))
     return FALSE;
+
+  /* Both codecalphademux and alphacombine elements were added in 1.19 */
+  if (GST_VERSION_MAJOR == 1 && GST_VERSION_MINOR >= 19) {
+    if (!gst_element_register (plugin, "mppvpxalphadecodebin",
+            GST_RANK_PRIMARY + GST_MPP_ALPHA_DECODE_BIN_RANK_OFFSET,
+            gst_mpp_vpx_alpha_decode_bin_get_type ()))
+      return FALSE;
+  }
 
   return TRUE;
 }

--- a/gst/rockchipmpp/gstmppalphadecodebin.c
+++ b/gst/rockchipmpp/gstmppalphadecodebin.c
@@ -1,0 +1,219 @@
+/* GStreamer
+ * Copyright (C) <2021> Collabora Ltd.
+ *   Author: Nicolas Dufresne <nicolas.dufresne@collabora.com>
+ *   Author: Julian Bouzas <julian.bouzas@collabora.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gst/pbutils/pbutils.h>
+
+#include "gstmppalphadecodebin.h"
+
+GST_DEBUG_CATEGORY_STATIC (mppalphadecodebin_debug);
+#define GST_CAT_DEFAULT (mppalphadecodebin_debug)
+
+typedef struct
+{
+  GstBin parent;
+
+  gboolean constructed;
+  const gchar *missing_element;
+} GstMppAlphaDecodeBinPrivate;
+
+#define gst_mpp_alpha_decode_bin_parent_class parent_class
+G_DEFINE_ABSTRACT_TYPE_WITH_CODE (GstMppAlphaDecodeBin,
+    gst_mpp_alpha_decode_bin, GST_TYPE_BIN,
+    G_ADD_PRIVATE (GstMppAlphaDecodeBin);
+    GST_DEBUG_CATEGORY_INIT (mppalphadecodebin_debug, "mppalphadecodebin", 0,
+        "mppalphadecodebin"));
+
+static GstStaticPadTemplate gst_mpp_alpha_decode_bin_src_template =
+GST_STATIC_PAD_TEMPLATE ("src",
+    GST_PAD_SRC,
+    GST_PAD_ALWAYS,
+    GST_STATIC_CAPS ("ANY")
+    );
+
+static gboolean
+gst_mpp_alpha_decode_bin_open (GstMppAlphaDecodeBin * self)
+{
+  GstMppAlphaDecodeBinPrivate *priv =
+      gst_mpp_alpha_decode_bin_get_instance_private (self);
+
+  if (priv->missing_element) {
+    gst_element_post_message (GST_ELEMENT (self),
+        gst_missing_element_message_new (GST_ELEMENT (self),
+            priv->missing_element));
+  } else if (!priv->constructed) {
+    GST_ELEMENT_ERROR (self, CORE, FAILED,
+        ("Failed to construct mpp alpha decoder pipeline."), (NULL));
+  }
+
+  return priv->constructed;
+}
+
+static GstStateChangeReturn
+gst_mpp_alpha_decode_bin_change_state (GstElement * element,
+    GstStateChange transition)
+{
+  GstMppAlphaDecodeBin *self = GST_MPP_ALPHA_DECODE_BIN (element);
+
+  switch (transition) {
+    case GST_STATE_CHANGE_NULL_TO_READY:
+      if (!gst_mpp_alpha_decode_bin_open (self))
+        return GST_STATE_CHANGE_FAILURE;
+      break;
+    default:
+      break;
+  }
+
+  return GST_ELEMENT_CLASS (parent_class)->change_state (element, transition);
+}
+
+static void
+gst_mpp_alpha_decode_bin_constructed (GObject * obj)
+{
+  GstMppAlphaDecodeBin *self = GST_MPP_ALPHA_DECODE_BIN (obj);
+  GstMppAlphaDecodeBinPrivate *priv =
+      gst_mpp_alpha_decode_bin_get_instance_private (self);
+  GstMppAlphaDecodeBinClass *klass = GST_MPP_ALPHA_DECODE_BIN_GET_CLASS (self);
+  GstPad *src_gpad, *sink_gpad;
+  GstPad *src_pad = NULL, *sink_pad = NULL;
+  GstElement *alphademux = NULL;
+  GstElement *queue = NULL;
+  GstElement *alpha_queue = NULL;
+  GstElement *decoder = NULL;
+  GstElement *alpha_decoder = NULL;
+  GstElement *alphacombine = NULL;
+
+  /* setup ghost pads */
+  sink_gpad = gst_ghost_pad_new_no_target_from_template ("sink",
+      gst_element_class_get_pad_template (GST_ELEMENT_CLASS (klass), "sink"));
+  gst_element_add_pad (GST_ELEMENT (self), sink_gpad);
+
+  src_gpad = gst_ghost_pad_new_no_target_from_template ("src",
+      gst_element_class_get_pad_template (GST_ELEMENT_CLASS (klass), "src"));
+  gst_element_add_pad (GST_ELEMENT (self), src_gpad);
+
+  /* create elements */
+  alphademux = gst_element_factory_make ("codecalphademux", NULL);
+  if (!alphademux) {
+    priv->missing_element = "codecalphademux";
+    goto cleanup;
+  }
+
+  queue = gst_element_factory_make ("queue", NULL);
+  alpha_queue = gst_element_factory_make ("queue", NULL);
+  if (!queue || !alpha_queue) {
+    priv->missing_element = "queue";
+    goto cleanup;
+  }
+
+  decoder = gst_element_factory_make (klass->decoder_name, "maindec");
+  if (!decoder) {
+    priv->missing_element = klass->decoder_name;
+    goto cleanup;
+  }
+
+  alpha_decoder = gst_element_factory_make (klass->decoder_name, "alphadec");
+  if (!alpha_decoder) {
+    priv->missing_element = klass->decoder_name;
+    goto cleanup;
+  }
+
+  /* We disable QoS on decoders because we need to maintain frame pairing in
+   * order for alphacombine to work. */
+  g_object_set (decoder, "qos", FALSE, NULL);
+  g_object_set (alpha_decoder, "qos", FALSE, NULL);
+
+  alphacombine = gst_element_factory_make ("alphacombine", NULL);
+  if (!alphacombine) {
+    priv->missing_element = "alphacombine";
+    goto cleanup;
+  }
+
+  gst_bin_add_many (GST_BIN (self), alphademux, queue, alpha_queue, decoder,
+      alpha_decoder, alphacombine, NULL);
+
+  /* link elements */
+  sink_pad = gst_element_get_static_pad (alphademux, "sink");
+  gst_ghost_pad_set_target (GST_GHOST_PAD (sink_gpad), sink_pad);
+  gst_object_unref (sink_pad);
+
+  gst_element_link_pads (alphademux, "src", queue, "sink");
+  gst_element_link_pads (queue, "src", decoder, "sink");
+  gst_element_link_pads (decoder, "src", alphacombine, "sink");
+
+  gst_element_link_pads (alphademux, "alpha", alpha_queue, "sink");
+  gst_element_link_pads (alpha_queue, "src", alpha_decoder, "sink");
+  gst_element_link_pads (alpha_decoder, "src", alphacombine, "alpha");
+
+  src_pad = gst_element_get_static_pad (alphacombine, "src");
+  gst_ghost_pad_set_target (GST_GHOST_PAD (src_gpad), src_pad);
+  gst_object_unref (src_pad);
+
+  g_object_set (queue, "max-size-bytes", 0, "max-size-time", 0,
+      "max-size-buffers", 1, NULL);
+  g_object_set (alpha_queue, "max-size-bytes", 0, "max-size-time", 0,
+      "max-size-buffers", 1, NULL);
+
+  /* signal success, we will handle this in NULL->READY transition */
+  priv->constructed = TRUE;
+  return;
+
+cleanup:
+  if (alphademux)
+    gst_object_unref (alphademux);
+  if (queue)
+    gst_object_unref (queue);
+  if (alpha_queue)
+    gst_object_unref (alpha_queue);
+  if (decoder)
+    gst_object_unref (decoder);
+  if (alpha_decoder)
+    gst_object_unref (alpha_decoder);
+  if (alphacombine)
+    gst_object_unref (alphacombine);
+
+  G_OBJECT_CLASS (parent_class)->constructed (obj);
+}
+
+static void
+gst_mpp_alpha_decode_bin_class_init (GstMppAlphaDecodeBinClass * klass)
+{
+  GstElementClass *element_class = (GstElementClass *) klass;
+  GObjectClass *obj_class = (GObjectClass *) klass;
+
+  /* This is needed to access the subclass class instance, otherwise we cannot
+   * read the class parameters */
+  obj_class->constructed = gst_mpp_alpha_decode_bin_constructed;
+
+  gst_element_class_add_static_pad_template (element_class,
+      &gst_mpp_alpha_decode_bin_src_template);
+  element_class->change_state =
+      GST_DEBUG_FUNCPTR (gst_mpp_alpha_decode_bin_change_state);
+}
+
+static void
+gst_mpp_alpha_decode_bin_init (GstMppAlphaDecodeBin * self)
+{
+  (void) self;
+}

--- a/gst/rockchipmpp/gstmppalphadecodebin.h
+++ b/gst/rockchipmpp/gstmppalphadecodebin.h
@@ -1,0 +1,48 @@
+/* GStreamer
+ * Copyright (C) <2021> Collabora Ltd.
+ *   Author: Nicolas Dufresne <nicolas.dufresne@collabora.com>
+ *   Author: Julian Bouzas <julian.bouzas@collabora.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __GST_MPP_ALPHA_DECODE_BIN_H__
+#define __GST_MPP_ALPHA_DECODE_BIN_H__
+
+#include <gst/gst.h>
+
+/* When wrapping, use the original rank plus this offset. The ad-hoc rules is
+ * that hardware implementation will use PRIMARY+1 or +2 to override the
+ * software decoder, so the offset must be large enough to jump over those.
+ * This should also be small enough so that a marginal (64) or secondary
+ * wrapper does not cross the PRIMARY line.
+ */
+#define GST_MPP_ALPHA_DECODE_BIN_RANK_OFFSET 10
+
+G_BEGIN_DECLS
+#define GST_TYPE_MPP_ALPHA_DECODE_BIN (gst_mpp_alpha_decode_bin_get_type())
+G_DECLARE_DERIVABLE_TYPE (GstMppAlphaDecodeBin,
+    gst_mpp_alpha_decode_bin, GST, MPP_ALPHA_DECODE_BIN, GstBin);
+
+struct _GstMppAlphaDecodeBinClass
+{
+  GstBinClass parent_class;
+
+  const gchar *decoder_name;
+};
+
+G_END_DECLS
+#endif

--- a/gst/rockchipmpp/gstmppvpxalphadecodebin.c
+++ b/gst/rockchipmpp/gstmppvpxalphadecodebin.c
@@ -1,0 +1,71 @@
+/* GStreamer
+ * Copyright (C) <2021> Collabora Ltd.
+ *   Author: Nicolas Dufresne <nicolas.dufresne@collabora.com>
+ *   Author: Julian Bouzas <julian.bouzas@collabora.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+/**
+ * SECTION:element-mppvpxalphadecodebin
+ * @title: Wrapper to decode MPP VP8/VP9 alpha using mppvideodec
+ *
+ * Use two `mppvideodec` instance in order to decode VP8/VP9 alpha channel.
+ *
+ * Since: 1.20
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "gstmppvpxalphadecodebin.h"
+
+static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",
+    GST_PAD_SINK,
+    GST_PAD_ALWAYS,
+    GST_STATIC_CAPS ("video/x-vp8, codec-alpha = (boolean) true; "
+        "video/x-vp9, codec-alpha = (boolean) true"));
+
+struct _GstMppVpxAlphaDecodeBin
+{
+  GstMppAlphaDecodeBin parent;
+};
+
+#define gst_mpp_vpx_alpha_decode_bin_parent_class parent_class
+G_DEFINE_TYPE (GstMppVpxAlphaDecodeBin, gst_mpp_vpx_alpha_decode_bin,
+    GST_TYPE_MPP_ALPHA_DECODE_BIN);
+
+static void
+gst_mpp_vpx_alpha_decode_bin_class_init (GstMppVpxAlphaDecodeBinClass * klass)
+{
+  GstMppAlphaDecodeBinClass *adbin_class = (GstMppAlphaDecodeBinClass *) klass;
+  GstElementClass *element_class = (GstElementClass *) klass;
+
+  adbin_class->decoder_name = "mppvideodec";
+  gst_element_class_add_static_pad_template (element_class, &sink_template);
+
+  gst_element_class_set_static_metadata (element_class,
+      "VP8/VP9 Alpha Decoder", "Codec/Decoder/Video",
+      "Wrapper bin to decode VP8/VP9 with alpha stream.",
+      "Julian Bouzas <julian.bouzas@collabora.com>");
+}
+
+static void
+gst_mpp_vpx_alpha_decode_bin_init (GstMppVpxAlphaDecodeBin * self)
+{
+  (void) self;
+}

--- a/gst/rockchipmpp/gstmppvpxalphadecodebin.h
+++ b/gst/rockchipmpp/gstmppvpxalphadecodebin.h
@@ -1,0 +1,34 @@
+/* GStreamer
+ * Copyright (C) <2021> Collabora Ltd.
+ *   Author: Nicolas Dufresne <nicolas.dufresne@collabora.com>
+ *   Author: Julian Bouzas <julian.bouzas@collabora.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __GST_MPP_VPX_ALPHA_DECODE_BIN_H__
+#define __GST_MPP_VPX_ALPHA_DECODE_BIN_H__
+
+#include "gstmppalphadecodebin.h"
+
+G_BEGIN_DECLS
+#define GST_TYPE_MPP_VPX_ALPHA_DECODE_BIN (gst_mpp_vpx_alpha_decode_bin_get_type())
+G_DECLARE_FINAL_TYPE (GstMppVpxAlphaDecodeBin,
+    gst_mpp_vpx_alpha_decode_bin, GST, MPP_VPX_ALPHA_DECODE_BIN,
+    GstMppAlphaDecodeBin);
+
+G_END_DECLS
+#endif

--- a/gst/rockchipmpp/meson.build
+++ b/gst/rockchipmpp/meson.build
@@ -9,6 +9,8 @@ rockchipmpp_sources = [
   'gstmpph264enc.c',
   'gstmpph265enc.c',
   'gstmppvp8enc.c',
+  'gstmppalphadecodebin.c',
+  'gstmppvpxalphadecodebin.c',
 ]
 
 if not mpp_dep.found()
@@ -19,7 +21,7 @@ rockchipmpp = library('gstrockchipmpp',
   rockchipmpp_sources,
   c_args : [gst_rockchip_args, '-Wextra'],
   include_directories : [configinc, libsinc],
-  dependencies : [gstbase_dep, gstvideo_dep, gstallocators_dep, mpp_dep, rga_dep],
+  dependencies : [gstbase_dep, gstvideo_dep, gstallocators_dep, gstpbutils_dep, mpp_dep, rga_dep],
   install : true,
   install_dir : plugins_install_dir,
 )

--- a/meson.build
+++ b/meson.build
@@ -80,6 +80,8 @@ gstallocators_dep = dependency('gstreamer-allocators-1.0', version : gst_req,
   fallback : ['gst-plugins-base', 'allocators_dep'])
 gstvideo_dep = dependency('gstreamer-video-1.0', version : gst_req,
   fallback : ['gst-plugins-base', 'video_dep'])
+gstpbutils_dep = dependency('gstreamer-pbutils-1.0', version : gst_req,
+  fallback : ['gst-plugins-base', 'pbutils_dep'])
 
 glib_dep = dependency('glib-2.0', version : glib_req,
   fallback : ['glib', 'libglib_dep'])


### PR DESCRIPTION
Similar to gst-plugins-bad's [codecalpha](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/tree/main/subprojects/gst-plugins-bad/gst/codecalpha), this PR adds a new `mppvpxalphadecodebin` element that wraps the existing mppvideodec decoder to allow decoding the alpha channel of VP8 and VP9 videos.

In VP8 and VP9 videos, the alpha channel needs to be decoded separately and in parallel with the rest of the video, so 2 instances of `mppvideodec` are needed: one to decode the actualy video, and another one to decode the alpha channel. The way to do this in GStreamer is implement a bin that separates the alpha channel with the `codecalhademux` element, then decode separately alpha and video with `mppvideodec`, and finally combine them with the `alphacombine` element:

                                                 .-> queue (alpha) -> mppvideodec -.
    filesrc -> matroskademux -> codecalphademux -|                                 |-> alphacombine -> glimagesink
                                                 `-> queue (video) -> mppvideodec -'

The video format after alphacombine can be either AV12 (NV12 with alpha) or A420 (I420 with alpha). If you use a sink that supports those formats such as `glimagesink`, you should be able to see the video with transparent background.

Here is a VP9 sample video with alpha: 

You can test it with: https://www.dropbox.com/s/zsdhnum3rmlq3kg/file.webm?dl=0

    gst-launch-1.0 filesrc location=file.webm ! matroskademux ! mppvpxalphadecodebin ! glimagesink
    
 Or:
 
    gst-launch-1.0 filesrc location=file.webm ! decodebin ! glimagesink

Here is the gstreamer dot graph of the first pipeline: 
![pipeline](https://user-images.githubusercontent.com/48253386/143057451-232982ee-0caa-4200-8cb5-c41ff816cbc5.png)


Without the `mppvpxalphadecodebin` element, it is not possible for the autoplug system to work with decodebin if the VP8/VP9 file has alpha channel (it will just decode the video ignoring the alpha channel). Having the `mppvpxalphadecodebin` element allows decodebin to decode alpha channel automatically, without needing to define the pipeline manually (requirement in some applications):

    gst-launch-1.0 filesrc location=file.webm ! matroskademux ! codecalphademux name=ad ad.src ! queue ! mppvideodec ! co.sink ad.alpha ! queue ! mppvideodec ! co.alpha alphacombine name=co ! glimagesink
    
